### PR TITLE
Order by time by default

### DIFF
--- a/mvc/view.php
+++ b/mvc/view.php
@@ -49,6 +49,7 @@
     "lengthMenu": [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],
     autoWidth: false,
     "lengthChange": true,
+    "order": [ 1, 'desc' ],
     "columnDefs": [
       { "width": "40%", "targets": [2] }
     ]


### PR DESCRIPTION
Current default is ordering by user which doesn't make so much sense for a log. I find myself always reordering the log whenever I use it.
I guess this was not changed yet because on single user kirby installations it already behaves as expected.